### PR TITLE
Hybrid element

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ insert_final_newline = true
 
 [*.yml]
 indent_style = space
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/bower_components-1.x/*

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,15 +1,18 @@
 {
 	"env": {
-		"browser": true
+		"browser": true,
+		"es6": true
 	},
 	"extends": "eslint:recommended",
 	"globals": {
 		"Cosmoz": false,
 		"CustomElements": false,
 		"HTMLImports": false,
-		"moment": false,
 		"Polymer": false,
 		"WeakMap": false
+	},
+	"parserOptions": {
+		"ecmaVersion": 6
 	},
 	"plugins": [
 		"html"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bower_components/
+bower_components-1.x/
+bower-1.x.json
 node_modules/
 .eslintcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,15 @@ addons:
 cache:
   yarn: true
   directories:
-    - node_modules
-    - bower_components
-    - .eslintcache
-    - $HOME/.cache/bower
+  - node_modules
+  - bower_components
+  - bower_components-1.x
+  - ".eslintcache"
+  - "$HOME/.cache/bower"
 before_script:
-  - yarn run lint
+- yarn run lint
 script:
-  - xvfb-run yarn test
+- xvfb-run yarn test
 notifications:
   slack:
     secure: iiQaiEb8Zn1chQAfKDunAAIbXGEyTl723zJPYNz1WecSbMTtEIiCbACT/H5nOA8NbYLhkYVuMmBXgqyvctas3JiZ1cvueTua571Qb2ryhB0eqr0qslJOCj0N+uBpnfst5DwoUV2FkuQcwm0V4ExzXV3e78gRFeHqRhHo2KX4AcNrAL5Qydn74rFcTreAAsgj7PR/2eoPyBUBlzGb+Wb0ytPoDNbT4+Tw/8KDxRXahSUEgaJ2F/MkC0Kk2lGHkDFFkAwtTsqjASKUVyvjc4cuNuBIMIS528LmtKVYZBoOhrU0Yuxstg+sgo77mo8QMRkmp0P/u48dQZZJGhcUnoNbpMdMNyQq5TzoS98GzjPf4zeTsCtQyGW+ku36ofmDvIQLK3GD4nSAB9KrJQ0T5V8kgflSkYCnUqywDAmSkwG8eaUZZWKJX8wf5uEv2vOzrlYQCkf44j85msteF54QGcO7Nyb0b/eRuWPIX6Y9JAs397o6Be9MjL/uMbbMTAVsmfXQr69i9s75Sw3ARGZMhY7vQequbfqtnBPpsGp1qwHZqesOC5GHzjki+9+uyk9ypVE7PJTSR6908OC7ShV7SpX3+89i5kWZkEMmY8JxULEhmnNokWHMWM1qBCCZR+nGfak/aLBsT/xUjMw8UhGBIIdngVHTZaMT1meMob6DRpxvePs=

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+
+{
+	"eslint.autoFixOnSave": true,
+	"eslint.validate": [
+		{ "language": "javascript", "autoFix": true },
+		{ "language": "html", "autoFix": true }
+	]
+}

--- a/analysis.json
+++ b/analysis.json
@@ -13,11 +13,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 28,
+              "line": 29,
               "column": 4
             },
             "end": {
-              "line": 30,
+              "line": 31,
               "column": 5
             }
           },
@@ -32,11 +32,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 32,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 34,
+              "line": 35,
               "column": 5
             }
           },
@@ -51,11 +51,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 41,
+              "line": 42,
               "column": 3
             },
             "end": {
-              "line": 41,
+              "line": 42,
               "column": 21
             }
           },
@@ -70,11 +70,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 43,
+              "line": 44,
               "column": 3
             },
             "end": {
-              "line": 43,
+              "line": 44,
               "column": 32
             }
           },
@@ -89,11 +89,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 45,
+              "line": 46,
               "column": 3
             },
             "end": {
-              "line": 45,
+              "line": 46,
               "column": 19
             }
           },
@@ -108,11 +108,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 69,
+              "line": 70,
               "column": 3
             },
             "end": {
-              "line": 71,
+              "line": 72,
               "column": 4
             }
           },
@@ -218,11 +218,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 47,
+              "line": 48,
               "column": 3
             },
             "end": {
-              "line": 49,
+              "line": 50,
               "column": 4
             }
           },
@@ -235,11 +235,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 51,
+              "line": 52,
               "column": 3
             },
             "end": {
-              "line": 56,
+              "line": 57,
               "column": 4
             }
           },
@@ -252,11 +252,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 58,
+              "line": 59,
               "column": 3
             },
             "end": {
-              "line": 67,
+              "line": 68,
               "column": 4
             }
           },
@@ -269,11 +269,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 73,
+              "line": 74,
               "column": 3
             },
             "end": {
-              "line": 82,
+              "line": 83,
               "column": 4
             }
           },
@@ -286,11 +286,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 84,
+              "line": 85,
               "column": 3
             },
             "end": {
-              "line": 88,
+              "line": 89,
               "column": 4
             }
           },
@@ -303,11 +303,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 90,
+              "line": 91,
               "column": 3
             },
             "end": {
-              "line": 94,
+              "line": 95,
               "column": 4
             }
           },
@@ -320,11 +320,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 96,
+              "line": 97,
               "column": 3
             },
             "end": {
-              "line": 118,
+              "line": 119,
               "column": 4
             }
           },
@@ -337,11 +337,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 120,
+              "line": 121,
               "column": 3
             },
             "end": {
-              "line": 124,
+              "line": 125,
               "column": 4
             }
           },
@@ -361,11 +361,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 126,
+              "line": 127,
               "column": 3
             },
             "end": {
-              "line": 130,
+              "line": 131,
               "column": 4
             }
           },
@@ -381,15 +381,20 @@
         }
       ],
       "staticMethods": [],
-      "demos": [],
+      "demos": [
+        {
+          "url": "demo/index2.html",
+          "description": "Dialog2 Demo"
+        }
+      ],
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 23,
+          "line": 24,
           "column": 10
         },
         "end": {
-          "line": 131,
+          "line": 132,
           "column": 3
         }
       },
@@ -401,11 +406,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 28,
+              "line": 29,
               "column": 4
             },
             "end": {
-              "line": 30,
+              "line": 31,
               "column": 5
             }
           },
@@ -417,11 +422,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 32,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 34,
+              "line": 35,
               "column": 5
             }
           },
@@ -441,11 +446,11 @@
           "range": {
             "file": "cosmoz-dialog2.html",
             "start": {
-              "line": 15,
+              "line": 16,
               "column": 3
             },
             "end": {
-              "line": 15,
+              "line": 16,
               "column": 16
             }
           }
@@ -2839,7 +2844,7 @@
         },
         {
           "name": "_beforeOpened",
-          "description": "",
+          "description": "eslint-disable-next-line no-unused-vars",
           "privacy": "protected",
           "sourceRange": {
             "start": {
@@ -2881,20 +2886,26 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 81,
+              "line": 83,
               "column": 3
             },
             "end": {
-              "line": 155,
+              "line": 157,
               "column": 4
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "nodeOrObject"
+              "name": "nodeOrObject",
+              "type": "(HTMLElement|Object)",
+              "description": "The node to get context for"
             }
-          ]
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "The closest stacking context"
+          }
         }
       ],
       "staticMethods": [],
@@ -2911,7 +2922,7 @@
           "column": 10
         },
         "end": {
-          "line": 156,
+          "line": 158,
           "column": 3
         }
       },
@@ -3381,7 +3392,23 @@
         "cssVariables": [],
         "selectors": []
       },
-      "slots": [],
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "cosmoz-dialog.html",
+            "start": {
+              "line": 21,
+              "column": 2
+            },
+            "end": {
+              "line": 21,
+              "column": 15
+            }
+          }
+        }
+      ],
       "tagname": "cosmoz-dialog"
     }
   ]

--- a/analysis.json
+++ b/analysis.json
@@ -1,0 +1,3898 @@
+{
+  "schema_version": "1.0.0",
+  "elements": [
+    {
+      "description": "`<cosmoz-dialog>` is a wrapper element for `<paper-dialog>`, but that will append a paper-dialog to a `<cosmoz-dialog-container>`\ncontainer element or to the `<body>` element if no container is available.\nThis is an attempt to workaround stacking context issues with dialogs.\n\nContent of the `<paper-dialog>` must be specified in a `<template>` element.",
+      "summary": "",
+      "path": "cosmoz-dialog2.html",
+      "properties": [
+        {
+          "name": "__hideTemplateChildren__",
+          "type": "?",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4240,
+              "column": 14
+            },
+            "end": {
+              "line": 4240,
+              "column": 73
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_showHideChildren\""
+            }
+          },
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_instanceProps",
+          "type": "Member",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4241,
+              "column": 0
+            },
+            "end": {
+              "line": 4241,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_parentPropPrefix",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4242,
+              "column": 0
+            },
+            "end": {
+              "line": 4242,
+              "column": 29
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "modal",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 28,
+              "column": 4
+            },
+            "end": {
+              "line": 30,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "withBackdrop",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 32,
+              "column": 4
+            },
+            "end": {
+              "line": 34,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_paperDialog",
+          "type": "object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 41,
+              "column": 3
+            },
+            "end": {
+              "line": 41,
+              "column": 21
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_dialogTemplateInstance",
+          "type": "object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 43,
+              "column": 3
+            },
+            "end": {
+              "line": 43,
+              "column": 32
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_container",
+          "type": "object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 45,
+              "column": 3
+            },
+            "end": {
+              "line": 45,
+              "column": 19
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "paperDialog",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 69,
+              "column": 3
+            },
+            "end": {
+              "line": 71,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "templatize",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4243,
+              "column": 0
+            },
+            "end": {
+              "line": 4275,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_getRootDataHost",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4276,
+              "column": 0
+            },
+            "end": {
+              "line": 4278,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_showHideChildrenImpl",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4279,
+              "column": 0
+            },
+            "end": {
+              "line": 4302,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "hide"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "__setPropertyImpl",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4303,
+              "column": 0
+            },
+            "end": {
+              "line": 4308,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property"
+            },
+            {
+              "name": "value"
+            },
+            {
+              "name": "fromAbove"
+            },
+            {
+              "name": "node"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_debounceTemplate",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4309,
+              "column": 0
+            },
+            "end": {
+              "line": 4311,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "fn"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_flushTemplates",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4312,
+              "column": 0
+            },
+            "end": {
+              "line": 4314,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_customPrepEffects",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4315,
+              "column": 0
+            },
+            "end": {
+              "line": 4323,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "archetype"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_customPrepAnnotations",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4324,
+              "column": 0
+            },
+            "end": {
+              "line": 4340,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "archetype"
+            },
+            {
+              "name": "template"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_prepParentProperties",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4341,
+              "column": 0
+            },
+            "end": {
+              "line": 4386,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "archetype"
+            },
+            {
+              "name": "template"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_createForwardPropEffector",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4387,
+              "column": 0
+            },
+            "end": {
+              "line": 4391,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "prop"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_createHostPropEffector",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4392,
+              "column": 0
+            },
+            "end": {
+              "line": 4397,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "prop"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_createInstancePropEffector",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4398,
+              "column": 0
+            },
+            "end": {
+              "line": 4404,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "prop"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_extendTemplate",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4405,
+              "column": 0
+            },
+            "end": {
+              "line": 4423,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template"
+            },
+            {
+              "name": "proto"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_showHideChildren",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4424,
+              "column": 0
+            },
+            "end": {
+              "line": 4425,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "hidden"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_forwardInstancePath",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4426,
+              "column": 0
+            },
+            "end": {
+              "line": 4427,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "inst"
+            },
+            {
+              "name": "path"
+            },
+            {
+              "name": "value"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_forwardInstanceProp",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4428,
+              "column": 0
+            },
+            "end": {
+              "line": 4429,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "inst"
+            },
+            {
+              "name": "prop"
+            },
+            {
+              "name": "value"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_notifyPathUpImpl",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4430,
+              "column": 0
+            },
+            "end": {
+              "line": 4437,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path"
+            },
+            {
+              "name": "value"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_pathEffectorImpl",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4438,
+              "column": 0
+            },
+            "end": {
+              "line": 4449,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path"
+            },
+            {
+              "name": "value"
+            },
+            {
+              "name": "fromAbove"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_constructorImpl",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4450,
+              "column": 0
+            },
+            "end": {
+              "line": 4472,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "model"
+            },
+            {
+              "name": "host"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_listenImpl",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4473,
+              "column": 0
+            },
+            "end": {
+              "line": 4482,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node"
+            },
+            {
+              "name": "eventName"
+            },
+            {
+              "name": "methodName"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "_scopeElementClassImpl",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4483,
+              "column": 0
+            },
+            "end": {
+              "line": 4489,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node"
+            },
+            {
+              "name": "value"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "stamp",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4490,
+              "column": 0
+            },
+            "end": {
+              "line": 4501,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "model"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "modelForElement",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/polymer.html",
+            "start": {
+              "line": 4502,
+              "column": 0
+            },
+            "end": {
+              "line": 4515,
+              "column": 1
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "el"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 47,
+              "column": 3
+            },
+            "end": {
+              "line": 49,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "detached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 51,
+              "column": 3
+            },
+            "end": {
+              "line": 56,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 58,
+              "column": 3
+            },
+            "end": {
+              "line": 67,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "open",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 73,
+              "column": 3
+            },
+            "end": {
+              "line": 82,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "close",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 84,
+              "column": 3
+            },
+            "end": {
+              "line": 88,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "fit",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 90,
+              "column": 3
+            },
+            "end": {
+              "line": 94,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_createDialog",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 96,
+              "column": 3
+            },
+            "end": {
+              "line": 118,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_forwardParentProp",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 120,
+              "column": 3
+            },
+            "end": {
+              "line": 124,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "prop"
+            },
+            {
+              "name": "value"
+            }
+          ]
+        },
+        {
+          "name": "_forwardParentPath",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 126,
+              "column": 3
+            },
+            "end": {
+              "line": 130,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path"
+            },
+            {
+              "name": "value"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 23,
+          "column": 10
+        },
+        "end": {
+          "line": 131,
+          "column": 3
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "modal",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 28,
+              "column": 4
+            },
+            "end": {
+              "line": 30,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "with-backdrop",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 32,
+              "column": 4
+            },
+            "end": {
+              "line": 34,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "cosmoz-dialog2.html",
+            "start": {
+              "line": 15,
+              "column": 3
+            },
+            "end": {
+              "line": 15,
+              "column": 16
+            }
+          }
+        }
+      ],
+      "tagname": "cosmoz-dialog2"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "cosmoz-dialog-container.html",
+      "properties": [],
+      "methods": [
+        {
+          "name": "_onCosmozDialogAttached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 17,
+              "column": 3
+            },
+            "end": {
+              "line": 23,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 13,
+          "column": 10
+        },
+        "end": {
+          "line": 24,
+          "column": 3
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "cosmoz-dialog-container.html",
+            "start": {
+              "line": 6,
+              "column": 2
+            },
+            "end": {
+              "line": 6,
+              "column": 15
+            }
+          }
+        }
+      ],
+      "tagname": "cosmoz-dialog-container"
+    },
+    {
+      "description": "`<cosmoz-dialog>` is a dialog similar to `<paper-dialog>`, but that will fit the backdrop element\ninto the element specified by the `fitInto` property if present.\n\nThe `fitInto` property is inherited from Polymer.PaperDialogBehavior, which inherits it from Polymer.IronFitBehavior.\nWhen this property is specified, the dialog overlay will be centered inside the `fitInto` element.\n\nThis element can be used when you want to workaround `paper-dialog` behavior that fit the backdrop to the whole window.",
+      "summary": "",
+      "path": "cosmoz-dialog.html",
+      "properties": [
+        {
+          "name": "sizingTarget",
+          "type": "!Element",
+          "description": "The element that will receive a `max-height`/`width`. By default it is the same as `this`,\nbut it can be set to a child element. This is useful, for example, for implementing a\nscrolling region inside the element.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 69,
+              "column": 6
+            },
+            "end": {
+              "line": 74,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "fitInto",
+          "type": "Object",
+          "description": "The element to fit `this` into.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 79,
+              "column": 6
+            },
+            "end": {
+              "line": 82,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "noOverlap",
+          "type": "boolean",
+          "description": "Will position the element around the positionTarget without overlapping it.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 87,
+              "column": 6
+            },
+            "end": {
+              "line": 89,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "positionTarget",
+          "type": "!Element",
+          "description": "The element that should be used to position the element. If not set, it will\ndefault to the parent node.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 96,
+              "column": 6
+            },
+            "end": {
+              "line": 98,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "horizontalAlign",
+          "type": "string",
+          "description": "The orientation against which to align the element horizontally\nrelative to the `positionTarget`. Possible values are \"left\", \"right\", \"auto\".",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 104,
+              "column": 6
+            },
+            "end": {
+              "line": 106,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "verticalAlign",
+          "type": "string",
+          "description": "The orientation against which to align the element vertically\nrelative to the `positionTarget`. Possible values are \"top\", \"bottom\", \"auto\".",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 112,
+              "column": 6
+            },
+            "end": {
+              "line": 114,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "dynamicAlign",
+          "type": "boolean",
+          "description": "If true, it will use `horizontalAlign` and `verticalAlign` values as preferred alignment\nand if there's not enough space, it will pick the values which minimize the cropping.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 120,
+              "column": 6
+            },
+            "end": {
+              "line": 122,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "horizontalOffset",
+          "type": "number",
+          "description": "A pixel value that will be added to the position calculated for the\ngiven `horizontalAlign`, in the direction of alignment. You can think\nof it as increasing or decreasing the distance to the side of the\nscreen given by `horizontalAlign`.\n\nIf `horizontalAlign` is \"left\", this offset will increase or decrease\nthe distance to the left side of the screen: a negative offset will\nmove the dropdown to the left; a positive one, to the right.\n\nConversely if `horizontalAlign` is \"right\", this offset will increase\nor decrease the distance to the right side of the screen: a negative\noffset will move the dropdown to the right; a positive one, to the left.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 138,
+              "column": 6
+            },
+            "end": {
+              "line": 142,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "0",
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "verticalOffset",
+          "type": "number",
+          "description": "A pixel value that will be added to the position calculated for the\ngiven `verticalAlign`, in the direction of alignment. You can think\nof it as increasing or decreasing the distance to the side of the\nscreen given by `verticalAlign`.\n\nIf `verticalAlign` is \"top\", this offset will increase or decrease\nthe distance to the top side of the screen: a negative offset will\nmove the dropdown upwards; a positive one, downwards.\n\nConversely if `verticalAlign` is \"bottom\", this offset will increase\nor decrease the distance to the bottom side of the screen: a negative\noffset will move the dropdown downwards; a positive one, upwards.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 158,
+              "column": 6
+            },
+            "end": {
+              "line": 162,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "0",
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "autoFitOnAttach",
+          "type": "boolean",
+          "description": "Set to true to auto-fit on attach.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 167,
+              "column": 6
+            },
+            "end": {
+              "line": 170,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false",
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "_fitInfo",
+          "type": "?Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 173,
+              "column": 6
+            },
+            "end": {
+              "line": 175,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "_parentResizable",
+          "type": "Object",
+          "description": "The closest ancestor element that implements `IronResizableBehavior`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 36,
+              "column": 6
+            },
+            "end": {
+              "line": 39,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_parentResizableChanged\""
+            }
+          },
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "_notifyingDescendant",
+          "type": "boolean",
+          "description": "True if this element is currently notifying its descendant elements of\nresize.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 45,
+              "column": 6
+            },
+            "end": {
+              "line": 48,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false",
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "opened",
+          "type": "boolean",
+          "description": "True if the overlay is currently displayed.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 28,
+              "column": 6
+            },
+            "end": {
+              "line": 33,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "observer": "\"_openedChanged\""
+            }
+          },
+          "defaultValue": "false",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "canceled",
+          "type": "boolean",
+          "description": "True if the overlay was canceled when it was last closed.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 38,
+              "column": 6
+            },
+            "end": {
+              "line": 43,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_canceledChanged\"",
+              "readOnly": true
+            }
+          },
+          "defaultValue": "false",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "withBackdrop",
+          "type": "boolean",
+          "description": "Set to true to display a backdrop behind the overlay. It traps the focus\nwithin the light DOM of the overlay.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 49,
+              "column": 6
+            },
+            "end": {
+              "line": 52,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_withBackdropChanged\""
+            }
+          },
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "noAutoFocus",
+          "type": "boolean",
+          "description": "Set to true to disable auto-focusing the overlay or child nodes with\nthe `autofocus` attribute` when the overlay is opened.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 58,
+              "column": 6
+            },
+            "end": {
+              "line": 61,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "noCancelOnEscKey",
+          "type": "boolean",
+          "description": "Set to true to disable canceling the overlay with the ESC key.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 66,
+              "column": 6
+            },
+            "end": {
+              "line": 69,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "noCancelOnOutsideClick",
+          "type": "boolean",
+          "description": "Set to true to disable canceling the overlay by clicking outside it.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 74,
+              "column": 6
+            },
+            "end": {
+              "line": 77,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "closingReason",
+          "type": "Object",
+          "description": "Contains the reason(s) this overlay was last closed (see `iron-overlay-closed`).\n`IronOverlayBehavior` provides the `canceled` reason; implementers of the\nbehavior can provide other reasons in addition to `canceled`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 84,
+              "column": 6
+            },
+            "end": {
+              "line": 88,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "restoreFocusOnClose",
+          "type": "boolean",
+          "description": "Set to true to enable restoring of focus when overlay is closed.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 93,
+              "column": 6
+            },
+            "end": {
+              "line": 96,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "alwaysOnTop",
+          "type": "boolean",
+          "description": "Set to true to keep overlay always on top.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 101,
+              "column": 6
+            },
+            "end": {
+              "line": 103,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_manager",
+          "type": "Polymer.IronOverlayManagerClass",
+          "description": "Shortcut to access to the overlay manager.",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 110,
+              "column": 6
+            },
+            "end": {
+              "line": 113,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_focusedChild",
+          "type": "?Node",
+          "description": "The node being focused.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 119,
+              "column": 6
+            },
+            "end": {
+              "line": 121,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "hostAttributes",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/paper-dialog-behavior/paper-dialog-behavior.html",
+            "start": {
+              "line": 54,
+              "column": 4
+            },
+            "end": {
+              "line": 57,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.PaperDialogBehavior"
+        },
+        {
+          "name": "modal",
+          "type": "boolean",
+          "description": "If `modal` is true, this implies `no-cancel-on-outside-click`, `no-cancel-on-esc-key` and `with-backdrop`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/paper-dialog-behavior/paper-dialog-behavior.html",
+            "start": {
+              "line": 64,
+              "column": 6
+            },
+            "end": {
+              "line": 67,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false",
+          "inheritedFrom": "Polymer.PaperDialogBehavior"
+        },
+        {
+          "name": "__readied",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/paper-dialog-behavior/paper-dialog-behavior.html",
+            "start": {
+              "line": 69,
+              "column": 6
+            },
+            "end": {
+              "line": 72,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false",
+          "inheritedFrom": "Polymer.PaperDialogBehavior"
+        },
+        {
+          "name": "animationConfig",
+          "type": "Object",
+          "description": "Animation configuration. See README for more info.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animatable-behavior.html",
+            "start": {
+              "line": 26,
+              "column": 6
+            },
+            "end": {
+              "line": 28,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Polymer.NeonAnimatableBehavior"
+        },
+        {
+          "name": "entryAnimation",
+          "type": "string",
+          "description": "Convenience property for setting an 'entry' animation. Do not set `animationConfig.entry`\nmanually if using this. The animated node is set to `this` if using this property.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animatable-behavior.html",
+            "start": {
+              "line": 34,
+              "column": 6
+            },
+            "end": {
+              "line": 37,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_entryAnimationChanged\""
+            }
+          },
+          "inheritedFrom": "Polymer.NeonAnimatableBehavior"
+        },
+        {
+          "name": "exitAnimation",
+          "type": "string",
+          "description": "Convenience property for setting an 'exit' animation. Do not set `animationConfig.exit`\nmanually if using this. The animated node is set to `this` if using this property.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animatable-behavior.html",
+            "start": {
+              "line": 43,
+              "column": 6
+            },
+            "end": {
+              "line": 46,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_exitAnimationChanged\""
+            }
+          },
+          "inheritedFrom": "Polymer.NeonAnimatableBehavior"
+        }
+      ],
+      "methods": [
+        {
+          "name": "_fitWidth",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 178,
+              "column": 4
+            },
+            "end": {
+              "line": 186,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "_fitHeight",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 188,
+              "column": 4
+            },
+            "end": {
+              "line": 196,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "_fitLeft",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 198,
+              "column": 4
+            },
+            "end": {
+              "line": 206,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "_fitTop",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 208,
+              "column": 4
+            },
+            "end": {
+              "line": 216,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "_defaultPositionTarget",
+          "description": "The element that should be used to position the element,\nif no position target is configured.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 222,
+              "column": 4
+            },
+            "end": {
+              "line": 230,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "_localeHorizontalAlign",
+          "description": "The horizontal align value, accounting for the RTL/LTR text direction.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 235,
+              "column": 4
+            },
+            "end": {
+              "line": 246,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 62,
+              "column": 4
+            },
+            "end": {
+              "line": 64,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "detached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 66,
+              "column": 4
+            },
+            "end": {
+              "line": 74,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "fit",
+          "description": "Positions and fits the element into the `fitInto` element.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 280,
+              "column": 4
+            },
+            "end": {
+              "line": 284,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "_discoverInfo",
+          "description": "Memoize information needed to position and size the target element.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 290,
+              "column": 4
+            },
+            "end": {
+              "line": 327,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "resetFit",
+          "description": "Resets the target element's position and size constraints, and clear\nthe memoized data.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 333,
+              "column": 4
+            },
+            "end": {
+              "line": 343,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "refit",
+          "description": "Equivalent to calling `resetFit()` and `fit()`. Useful to call this after\nthe element or the `fitInto` element has been resized, or if any of the\npositioning properties (e.g. `horizontalAlign, verticalAlign`) is updated.\nIt preserves the scroll position of the sizingTarget.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 351,
+              "column": 4
+            },
+            "end": {
+              "line": 358,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "position",
+          "description": "Positions the element according to `horizontalAlign, verticalAlign`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 363,
+              "column": 4
+            },
+            "end": {
+              "line": 413,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "constrain",
+          "description": "Constrains the size of the element to `fitInto` by setting `max-height`\nand/or `max-width`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 419,
+              "column": 4
+            },
+            "end": {
+              "line": 446,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "_sizeDimension",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 452,
+              "column": 4
+            },
+            "end": {
+              "line": 454,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "rect"
+            },
+            {
+              "name": "positionedBy"
+            },
+            {
+              "name": "start"
+            },
+            {
+              "name": "end"
+            },
+            {
+              "name": "extent"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "__sizeDimension",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 459,
+              "column": 4
+            },
+            "end": {
+              "line": 469,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "rect"
+            },
+            {
+              "name": "positionedBy"
+            },
+            {
+              "name": "start"
+            },
+            {
+              "name": "end"
+            },
+            {
+              "name": "extent"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "center",
+          "description": "Centers horizontally and vertically if not already positioned. This also sets\n`position:fixed`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 475,
+              "column": 4
+            },
+            "end": {
+              "line": 508,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "__getNormalizedRect",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 510,
+              "column": 4
+            },
+            "end": {
+              "line": 522,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "target"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "__getCroppedArea",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 524,
+              "column": 4
+            },
+            "end": {
+              "line": 528,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "position"
+            },
+            {
+              "name": "size"
+            },
+            {
+              "name": "fitRect"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "__getPosition",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 531,
+              "column": 4
+            },
+            "end": {
+              "line": 618,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "hAlign"
+            },
+            {
+              "name": "vAlign"
+            },
+            {
+              "name": "size"
+            },
+            {
+              "name": "positionRect"
+            },
+            {
+              "name": "fitRect"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "created",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 55,
+              "column": 4
+            },
+            "end": {
+              "line": 60,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "notifyResize",
+          "description": "Can be called to manually notify a resizable and its descendant\nresizables of a resize change.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 80,
+              "column": 4
+            },
+            "end": {
+              "line": 92,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "assignParentResizable",
+          "description": "Used to assign the closest resizable ancestor to this resizable\nif the ancestor detects a request for notifications.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 98,
+              "column": 4
+            },
+            "end": {
+              "line": 100,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "parentResizable"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "stopResizeNotificationsFor",
+          "description": "Used to remove a resizable descendant from the list of descendants\nthat should be notified of a resize change.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 106,
+              "column": 4
+            },
+            "end": {
+              "line": 113,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "target"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "resizerShouldNotify",
+          "description": "This method can be overridden to filter nested elements that should or\nshould not be notified by the current element. Return true if an element\nshould be notified, or false if it should not be notified.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 124,
+              "column": 4
+            },
+            "end": {
+              "line": 124,
+              "column": 59
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "element",
+              "type": "HTMLElement",
+              "description": "A candidate descendant element that\nimplements `IronResizableBehavior`."
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the `element` should be notified of resize."
+          },
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "_onDescendantIronResize",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 126,
+              "column": 4
+            },
+            "end": {
+              "line": 138,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "_fireResize",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 4
+            },
+            "end": {
+              "line": 145,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "_onIronRequestResizeNotifications",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 147,
+              "column": 4
+            },
+            "end": {
+              "line": 162,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "_parentResizableChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 164,
+              "column": 4
+            },
+            "end": {
+              "line": 168,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "parentResizable"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "_notifyDescendant",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 170,
+              "column": 4
+            },
+            "end": {
+              "line": 181,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "descendant"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "_requestResizeNotifications",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-resizable-behavior/iron-resizable-behavior.html",
+            "start": {
+              "line": 183,
+              "column": 4
+            },
+            "end": {
+              "line": 211,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronResizableBehavior"
+        },
+        {
+          "name": "backdropElement",
+          "description": "The backdrop element.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 133,
+              "column": 4
+            },
+            "end": {
+              "line": 135,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_focusNode",
+          "description": "Returns the node to give focus to.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 141,
+              "column": 4
+            },
+            "end": {
+              "line": 143,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_focusableNodes",
+          "description": "Array of nodes that can receive focus (overlay included), ordered by `tabindex`.\nThis is used to retrieve which is the first and last focusable nodes in order\nto wrap the focus for overlays `with-backdrop`.\n\nIf you know what is your content (specifically the first and last focusable children),\nyou can override this method to return only `[firstFocusable, lastFocusable];`",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 155,
+              "column": 4
+            },
+            "end": {
+              "line": 157,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/paper-dialog-behavior/paper-dialog-behavior.html",
+            "start": {
+              "line": 84,
+              "column": 4
+            },
+            "end": {
+              "line": 90,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PaperDialogBehavior"
+        },
+        {
+          "name": "toggle",
+          "description": "Toggle the opened state of the overlay.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 195,
+              "column": 4
+            },
+            "end": {
+              "line": 198,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "open",
+          "description": "Open the overlay.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 203,
+              "column": 4
+            },
+            "end": {
+              "line": 206,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "close",
+          "description": "Close the overlay.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 211,
+              "column": 4
+            },
+            "end": {
+              "line": 214,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "cancel",
+          "description": "Cancels the overlay.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 220,
+              "column": 4
+            },
+            "end": {
+              "line": 228,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event",
+              "type": "Event=",
+              "description": "The original event"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "invalidateTabbables",
+          "description": "Invalidates the cached tabbable nodes. To be called when any of the focusable\ncontent changes (e.g. a button is disabled).",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 234,
+              "column": 4
+            },
+            "end": {
+              "line": 236,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_ensureSetup",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 238,
+              "column": 4
+            },
+            "end": {
+              "line": 245,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_openedChanged",
+          "description": "Called when `opened` changes.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 252,
+              "column": 4
+            },
+            "end": {
+              "line": 269,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "opened",
+              "type": "boolean="
+            }
+          ],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_canceledChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 271,
+              "column": 4
+            },
+            "end": {
+              "line": 274,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_withBackdropChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 276,
+              "column": 4
+            },
+            "end": {
+              "line": 288,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_prepareRenderOpened",
+          "description": "tasks which must occur before opening; e.g. making the element visible.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 294,
+              "column": 4
+            },
+            "end": {
+              "line": 310,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_renderOpened",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 59,
+              "column": 3
+            },
+            "end": {
+              "line": 62,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_renderClosed",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 64,
+              "column": 3
+            },
+            "end": {
+              "line": 67,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_finishRenderOpened",
+          "description": "Tasks to be performed at the end of open action. Will fire `iron-overlay-opened`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 332,
+              "column": 4
+            },
+            "end": {
+              "line": 337,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_finishRenderClosed",
+          "description": "Tasks to be performed at the end of close action. Will fire `iron-overlay-closed`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 343,
+              "column": 4
+            },
+            "end": {
+              "line": 351,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_preparePositioning",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 353,
+              "column": 4
+            },
+            "end": {
+              "line": 357,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_finishPositioning",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 359,
+              "column": 4
+            },
+            "end": {
+              "line": 372,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_applyFocus",
+          "description": "Applies focus according to the opened state.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 378,
+              "column": 4
+            },
+            "end": {
+              "line": 400,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_onCaptureClick",
+          "description": "Cancels (closes) the overlay. Call when click happens outside the overlay.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 407,
+              "column": 4
+            },
+            "end": {
+              "line": 411,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event",
+              "type": "!Event"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_onCaptureFocus",
+          "description": "Keeps track of the focused child. If withBackdrop, traps focus within overlay.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 418,
+              "column": 4
+            },
+            "end": {
+              "line": 429,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event",
+              "type": "!Event"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_onCaptureEsc",
+          "description": "Handles the ESC key event and cancels (closes) the overlay.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 436,
+              "column": 4
+            },
+            "end": {
+              "line": 440,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event",
+              "type": "!Event"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_onCaptureTab",
+          "description": "Handles TAB key events to track focus changes.\nWill wrap focus for overlays withBackdrop.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 448,
+              "column": 4
+            },
+            "end": {
+              "line": 490,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event",
+              "type": "!Event"
+            }
+          ],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_onIronResize",
+          "description": "Refits if the overlay is opened and not animating.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 496,
+              "column": 4
+            },
+            "end": {
+              "line": 500,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_onNodesChange",
+          "description": "Will call notifyResize if overlay is opened.\nCan be overridden in order to avoid multiple observers on the same node.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 507,
+              "column": 4
+            },
+            "end": {
+              "line": 513,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "__ensureFirstLastFocusables",
+          "description": "Will set first and last focusable nodes if any of them is not set.",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 519,
+              "column": 4
+            },
+            "end": {
+              "line": 525,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "__openedChanged",
+          "description": "Tasks executed when opened changes: prepare for the opening, move the\nfocus, update the manager, render opened/closed.",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 532,
+              "column": 4
+            },
+            "end": {
+              "line": 548,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "__onNextAnimationFrame",
+          "description": "Executes a callback on the next animation frame, overriding any previous\ncallback awaiting for the next animation frame. e.g.\n`__onNextAnimationFrame(callback1) && __onNextAnimationFrame(callback2)`;\n`callback1` will never be invoked.",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 558,
+              "column": 4
+            },
+            "end": {
+              "line": 567,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "callback",
+              "type": "!Function",
+              "description": "Its `this` parameter is the overlay itself."
+            }
+          ],
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "_modalChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/paper-dialog-behavior/paper-dialog-behavior.html",
+            "start": {
+              "line": 92,
+              "column": 4
+            },
+            "end": {
+              "line": 115,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "modal"
+            },
+            {
+              "name": "readied"
+            }
+          ],
+          "inheritedFrom": "Polymer.PaperDialogBehavior"
+        },
+        {
+          "name": "_updateClosingReasonConfirmed",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/paper-dialog-behavior/paper-dialog-behavior.html",
+            "start": {
+              "line": 117,
+              "column": 4
+            },
+            "end": {
+              "line": 120,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "confirmed"
+            }
+          ],
+          "inheritedFrom": "Polymer.PaperDialogBehavior"
+        },
+        {
+          "name": "_onDialogClick",
+          "description": "Will dismiss the dialog if user clicked on an element with dialog-dismiss\nor dialog-confirm attribute.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/paper-dialog-behavior/paper-dialog-behavior.html",
+            "start": {
+              "line": 126,
+              "column": 4
+            },
+            "end": {
+              "line": 139,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event"
+            }
+          ],
+          "inheritedFrom": "Polymer.PaperDialogBehavior"
+        },
+        {
+          "name": "_entryAnimationChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animatable-behavior.html",
+            "start": {
+              "line": 50,
+              "column": 4
+            },
+            "end": {
+              "line": 56,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.NeonAnimatableBehavior"
+        },
+        {
+          "name": "_exitAnimationChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animatable-behavior.html",
+            "start": {
+              "line": 58,
+              "column": 4
+            },
+            "end": {
+              "line": 64,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.NeonAnimatableBehavior"
+        },
+        {
+          "name": "_copyProperties",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animatable-behavior.html",
+            "start": {
+              "line": 66,
+              "column": 4
+            },
+            "end": {
+              "line": 71,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "config1"
+            },
+            {
+              "name": "config2"
+            }
+          ],
+          "inheritedFrom": "Polymer.NeonAnimatableBehavior"
+        },
+        {
+          "name": "_cloneConfig",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animatable-behavior.html",
+            "start": {
+              "line": 73,
+              "column": 4
+            },
+            "end": {
+              "line": 79,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "config"
+            }
+          ],
+          "inheritedFrom": "Polymer.NeonAnimatableBehavior"
+        },
+        {
+          "name": "_getAnimationConfigRecursive",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animatable-behavior.html",
+            "start": {
+              "line": 81,
+              "column": 4
+            },
+            "end": {
+              "line": 128,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type"
+            },
+            {
+              "name": "map"
+            },
+            {
+              "name": "allConfigs"
+            }
+          ],
+          "inheritedFrom": "Polymer.NeonAnimatableBehavior"
+        },
+        {
+          "name": "getAnimationConfig",
+          "description": "An element implementing `Polymer.NeonAnimationRunnerBehavior` calls this method to configure\nan animation with an optional type. Elements implementing `Polymer.NeonAnimatableBehavior`\nshould define the property `animationConfig`, which is either a configuration object\nor a map of animation type to array of configuration objects.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animatable-behavior.html",
+            "start": {
+              "line": 136,
+              "column": 4
+            },
+            "end": {
+              "line": 145,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type"
+            }
+          ],
+          "inheritedFrom": "Polymer.NeonAnimatableBehavior"
+        },
+        {
+          "name": "_configureAnimations",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animation-runner-behavior.html",
+            "start": {
+              "line": 22,
+              "column": 4
+            },
+            "end": {
+              "line": 54,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "configs"
+            }
+          ],
+          "inheritedFrom": "Polymer.NeonAnimationRunnerBehavior"
+        },
+        {
+          "name": "_shouldComplete",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animation-runner-behavior.html",
+            "start": {
+              "line": 56,
+              "column": 4
+            },
+            "end": {
+              "line": 65,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "activeEntries"
+            }
+          ],
+          "inheritedFrom": "Polymer.NeonAnimationRunnerBehavior"
+        },
+        {
+          "name": "_complete",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animation-runner-behavior.html",
+            "start": {
+              "line": 67,
+              "column": 4
+            },
+            "end": {
+              "line": 74,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "activeEntries"
+            }
+          ],
+          "inheritedFrom": "Polymer.NeonAnimationRunnerBehavior"
+        },
+        {
+          "name": "playAnimation",
+          "description": "Plays an animation with an optional `type`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animation-runner-behavior.html",
+            "start": {
+              "line": 81,
+              "column": 4
+            },
+            "end": {
+              "line": 110,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "string="
+            },
+            {
+              "name": "cookie",
+              "type": "!Object="
+            }
+          ],
+          "inheritedFrom": "Polymer.NeonAnimationRunnerBehavior"
+        },
+        {
+          "name": "cancelAnimation",
+          "description": "Cancels the currently running animations.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animation-runner-behavior.html",
+            "start": {
+              "line": 115,
+              "column": 4
+            },
+            "end": {
+              "line": 120,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.NeonAnimationRunnerBehavior"
+        },
+        {
+          "name": "_beforeOpened",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 45,
+              "column": 3
+            },
+            "end": {
+              "line": 57,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "opened"
+            }
+          ]
+        },
+        {
+          "name": "_onNeonAnimationFinish",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 69,
+              "column": 3
+            },
+            "end": {
+              "line": 75,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_getClosestStackingContext",
+          "description": "See https://github.com/gwwar/z-context/blob/master/devtools/index.js",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 80,
+              "column": 3
+            },
+            "end": {
+              "line": 154,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "nodeOrObject"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 27,
+          "column": 10
+        },
+        "end": {
+          "line": 155,
+          "column": 3
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "sizing-target",
+          "description": "The element that will receive a `max-height`/`width`. By default it is the same as `this`,\nbut it can be set to a child element. This is useful, for example, for implementing a\nscrolling region inside the element.",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 69,
+              "column": 6
+            },
+            "end": {
+              "line": 74,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "!Element",
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "fit-into",
+          "description": "The element to fit `this` into.",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 79,
+              "column": 6
+            },
+            "end": {
+              "line": 82,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "Object",
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "no-overlap",
+          "description": "Will position the element around the positionTarget without overlapping it.",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 87,
+              "column": 6
+            },
+            "end": {
+              "line": 89,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "position-target",
+          "description": "The element that should be used to position the element. If not set, it will\ndefault to the parent node.",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 96,
+              "column": 6
+            },
+            "end": {
+              "line": 98,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "!Element",
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "horizontal-align",
+          "description": "The orientation against which to align the element horizontally\nrelative to the `positionTarget`. Possible values are \"left\", \"right\", \"auto\".",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 104,
+              "column": 6
+            },
+            "end": {
+              "line": 106,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "vertical-align",
+          "description": "The orientation against which to align the element vertically\nrelative to the `positionTarget`. Possible values are \"top\", \"bottom\", \"auto\".",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 112,
+              "column": 6
+            },
+            "end": {
+              "line": 114,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "dynamic-align",
+          "description": "If true, it will use `horizontalAlign` and `verticalAlign` values as preferred alignment\nand if there's not enough space, it will pick the values which minimize the cropping.",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 120,
+              "column": 6
+            },
+            "end": {
+              "line": 122,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "horizontal-offset",
+          "description": "A pixel value that will be added to the position calculated for the\ngiven `horizontalAlign`, in the direction of alignment. You can think\nof it as increasing or decreasing the distance to the side of the\nscreen given by `horizontalAlign`.\n\nIf `horizontalAlign` is \"left\", this offset will increase or decrease\nthe distance to the left side of the screen: a negative offset will\nmove the dropdown to the left; a positive one, to the right.\n\nConversely if `horizontalAlign` is \"right\", this offset will increase\nor decrease the distance to the right side of the screen: a negative\noffset will move the dropdown to the right; a positive one, to the left.",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 138,
+              "column": 6
+            },
+            "end": {
+              "line": 142,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "number",
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "vertical-offset",
+          "description": "A pixel value that will be added to the position calculated for the\ngiven `verticalAlign`, in the direction of alignment. You can think\nof it as increasing or decreasing the distance to the side of the\nscreen given by `verticalAlign`.\n\nIf `verticalAlign` is \"top\", this offset will increase or decrease\nthe distance to the top side of the screen: a negative offset will\nmove the dropdown upwards; a positive one, downwards.\n\nConversely if `verticalAlign` is \"bottom\", this offset will increase\nor decrease the distance to the bottom side of the screen: a negative\noffset will move the dropdown downwards; a positive one, upwards.",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 158,
+              "column": 6
+            },
+            "end": {
+              "line": 162,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "number",
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "auto-fit-on-attach",
+          "description": "Set to true to auto-fit on attach.",
+          "sourceRange": {
+            "file": "bower_components/iron-fit-behavior/iron-fit-behavior.html",
+            "start": {
+              "line": 167,
+              "column": 6
+            },
+            "end": {
+              "line": 170,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "name": "opened",
+          "description": "True if the overlay is currently displayed.",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 28,
+              "column": 6
+            },
+            "end": {
+              "line": 33,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "canceled",
+          "description": "True if the overlay was canceled when it was last closed.",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 38,
+              "column": 6
+            },
+            "end": {
+              "line": 43,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "with-backdrop",
+          "description": "Set to true to display a backdrop behind the overlay. It traps the focus\nwithin the light DOM of the overlay.",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 49,
+              "column": 6
+            },
+            "end": {
+              "line": 52,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "no-auto-focus",
+          "description": "Set to true to disable auto-focusing the overlay or child nodes with\nthe `autofocus` attribute` when the overlay is opened.",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 58,
+              "column": 6
+            },
+            "end": {
+              "line": 61,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "no-cancel-on-esc-key",
+          "description": "Set to true to disable canceling the overlay with the ESC key.",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 66,
+              "column": 6
+            },
+            "end": {
+              "line": 69,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "no-cancel-on-outside-click",
+          "description": "Set to true to disable canceling the overlay by clicking outside it.",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 74,
+              "column": 6
+            },
+            "end": {
+              "line": 77,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "closing-reason",
+          "description": "Contains the reason(s) this overlay was last closed (see `iron-overlay-closed`).\n`IronOverlayBehavior` provides the `canceled` reason; implementers of the\nbehavior can provide other reasons in addition to `canceled`.",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 84,
+              "column": 6
+            },
+            "end": {
+              "line": 88,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "Object",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "restore-focus-on-close",
+          "description": "Set to true to enable restoring of focus when overlay is closed.",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 93,
+              "column": 6
+            },
+            "end": {
+              "line": 96,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "always-on-top",
+          "description": "Set to true to keep overlay always on top.",
+          "sourceRange": {
+            "file": "bower_components/iron-overlay-behavior/iron-overlay-behavior.html",
+            "start": {
+              "line": 101,
+              "column": 6
+            },
+            "end": {
+              "line": 103,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "name": "modal",
+          "description": "If `modal` is true, this implies `no-cancel-on-outside-click`, `no-cancel-on-esc-key` and `with-backdrop`.",
+          "sourceRange": {
+            "file": "bower_components/paper-dialog-behavior/paper-dialog-behavior.html",
+            "start": {
+              "line": 64,
+              "column": 6
+            },
+            "end": {
+              "line": 67,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Polymer.PaperDialogBehavior"
+        },
+        {
+          "name": "animation-config",
+          "description": "Animation configuration. See README for more info.",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animatable-behavior.html",
+            "start": {
+              "line": 26,
+              "column": 6
+            },
+            "end": {
+              "line": 28,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "Object",
+          "inheritedFrom": "Polymer.NeonAnimatableBehavior"
+        },
+        {
+          "name": "entry-animation",
+          "description": "Convenience property for setting an 'entry' animation. Do not set `animationConfig.entry`\nmanually if using this. The animated node is set to `this` if using this property.",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animatable-behavior.html",
+            "start": {
+              "line": 34,
+              "column": 6
+            },
+            "end": {
+              "line": 37,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Polymer.NeonAnimatableBehavior"
+        },
+        {
+          "name": "exit-animation",
+          "description": "Convenience property for setting an 'exit' animation. Do not set `animationConfig.exit`\nmanually if using this. The animated node is set to `this` if using this property.",
+          "sourceRange": {
+            "file": "bower_components/neon-animation/neon-animatable-behavior.html",
+            "start": {
+              "line": 43,
+              "column": 6
+            },
+            "end": {
+              "line": 46,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Polymer.NeonAnimatableBehavior"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "horizontal-offset-changed",
+          "description": "Fired when the `horizontalOffset` property changes.",
+          "metadata": {},
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "type": "CustomEvent",
+          "name": "vertical-offset-changed",
+          "description": "Fired when the `verticalOffset` property changes.",
+          "metadata": {},
+          "inheritedFrom": "Polymer.IronFitBehavior"
+        },
+        {
+          "type": "CustomEvent",
+          "name": "opened-changed",
+          "description": "Fired when the `opened` property changes.",
+          "metadata": {},
+          "inheritedFrom": "Polymer.IronOverlayBehaviorImpl"
+        },
+        {
+          "type": "CustomEvent",
+          "name": "iron-overlay-canceled",
+          "description": "iron-overlay-canceled",
+          "metadata": {},
+          "inheritedFrom": "Polymer.IronOverlayBehavior"
+        },
+        {
+          "type": "CustomEvent",
+          "name": "iron-overlay-closed",
+          "description": "iron-overlay-closed",
+          "metadata": {},
+          "inheritedFrom": "Polymer.IronOverlayBehavior"
+        },
+        {
+          "type": "CustomEvent",
+          "name": "iron-overlay-opened",
+          "description": "iron-overlay-opened",
+          "metadata": {},
+          "inheritedFrom": "Polymer.IronOverlayBehavior"
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "cosmoz-dialog"
+    }
+  ]
+}

--- a/analysis.json
+++ b/analysis.json
@@ -7,71 +7,6 @@
       "path": "cosmoz-dialog2.html",
       "properties": [
         {
-          "name": "__hideTemplateChildren__",
-          "type": "?",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4240,
-              "column": 14
-            },
-            "end": {
-              "line": 4240,
-              "column": 73
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "observer": "\"_showHideChildren\""
-            }
-          },
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_instanceProps",
-          "type": "Member",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4241,
-              "column": 0
-            },
-            "end": {
-              "line": 4241,
-              "column": 27
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_parentPropPrefix",
-          "type": "string",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4242,
-              "column": 0
-            },
-            "end": {
-              "line": 4242,
-              "column": 29
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
           "name": "modal",
           "type": "boolean",
           "description": "",
@@ -191,574 +126,90 @@
       "methods": [
         {
           "name": "templatize",
-          "description": "",
+          "description": "Generates an anonymous `TemplateInstance` class (stored as `this.ctor`)\nfor the provided template.  This method should be called once per\ntemplate to prepare an element for stamping the template, followed\nby `stamp` to create new instances of the template.",
           "privacy": "public",
           "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
+            "file": "bower_components/polymer/lib/legacy/templatizer-behavior.html",
             "start": {
-              "line": 4243,
-              "column": 0
+              "line": 105,
+              "column": 6
             },
             "end": {
-              "line": 4275,
-              "column": 1
+              "line": 114,
+              "column": 7
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "template"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_getRootDataHost",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4276,
-              "column": 0
-            },
-            "end": {
-              "line": 4278,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_showHideChildrenImpl",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4279,
-              "column": 0
-            },
-            "end": {
-              "line": 4302,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "hide"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "__setPropertyImpl",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4303,
-              "column": 0
-            },
-            "end": {
-              "line": 4308,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property"
+              "name": "template",
+              "type": "HTMLTemplateElement",
+              "description": "Template to prepare"
             },
             {
-              "name": "value"
-            },
-            {
-              "name": "fromAbove"
-            },
-            {
-              "name": "node"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_debounceTemplate",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4309,
-              "column": 0
-            },
-            "end": {
-              "line": 4311,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "fn"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_flushTemplates",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4312,
-              "column": 0
-            },
-            "end": {
-              "line": 4314,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_customPrepEffects",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4315,
-              "column": 0
-            },
-            "end": {
-              "line": 4323,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "archetype"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_customPrepAnnotations",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4324,
-              "column": 0
-            },
-            "end": {
-              "line": 4340,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "archetype"
-            },
-            {
-              "name": "template"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_prepParentProperties",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4341,
-              "column": 0
-            },
-            "end": {
-              "line": 4386,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "archetype"
-            },
-            {
-              "name": "template"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_createForwardPropEffector",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4387,
-              "column": 0
-            },
-            "end": {
-              "line": 4391,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "prop"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_createHostPropEffector",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4392,
-              "column": 0
-            },
-            "end": {
-              "line": 4397,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "prop"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_createInstancePropEffector",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4398,
-              "column": 0
-            },
-            "end": {
-              "line": 4404,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "prop"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_extendTemplate",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4405,
-              "column": 0
-            },
-            "end": {
-              "line": 4423,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template"
-            },
-            {
-              "name": "proto"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_showHideChildren",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4424,
-              "column": 0
-            },
-            "end": {
-              "line": 4425,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "hidden"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_forwardInstancePath",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4426,
-              "column": 0
-            },
-            "end": {
-              "line": 4427,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "inst"
-            },
-            {
-              "name": "path"
-            },
-            {
-              "name": "value"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_forwardInstanceProp",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4428,
-              "column": 0
-            },
-            "end": {
-              "line": 4429,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "inst"
-            },
-            {
-              "name": "prop"
-            },
-            {
-              "name": "value"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_notifyPathUpImpl",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4430,
-              "column": 0
-            },
-            "end": {
-              "line": 4437,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path"
-            },
-            {
-              "name": "value"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_pathEffectorImpl",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4438,
-              "column": 0
-            },
-            "end": {
-              "line": 4449,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path"
-            },
-            {
-              "name": "value"
-            },
-            {
-              "name": "fromAbove"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_constructorImpl",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4450,
-              "column": 0
-            },
-            "end": {
-              "line": 4472,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "model"
-            },
-            {
-              "name": "host"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_listenImpl",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4473,
-              "column": 0
-            },
-            "end": {
-              "line": 4482,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node"
-            },
-            {
-              "name": "eventName"
-            },
-            {
-              "name": "methodName"
-            }
-          ],
-          "inheritedFrom": "Polymer.Templatizer"
-        },
-        {
-          "name": "_scopeElementClassImpl",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
-            "start": {
-              "line": 4483,
-              "column": 0
-            },
-            "end": {
-              "line": 4489,
-              "column": 1
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node"
-            },
-            {
-              "name": "value"
+              "name": "mutableData",
+              "type": "boolean=",
+              "description": "When `true`, the generated class will skip\n  strict dirty-checking for objects and arrays (always consider them to\n  be \"dirty\"). Defaults to false."
             }
           ],
           "inheritedFrom": "Polymer.Templatizer"
         },
         {
           "name": "stamp",
-          "description": "",
+          "description": "Creates an instance of the template prepared by `templatize`.  The object\nreturned is an instance of the anonymous class generated by `templatize`\nwhose `root` property is a document fragment containing newly cloned\ntemplate content, and which has property accessors corresponding to\nproperties referenced in template bindings.",
           "privacy": "public",
           "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
+            "file": "bower_components/polymer/lib/legacy/templatizer-behavior.html",
             "start": {
-              "line": 4490,
-              "column": 0
+              "line": 129,
+              "column": 6
             },
             "end": {
-              "line": 4501,
-              "column": 1
+              "line": 131,
+              "column": 7
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "model"
+              "name": "model",
+              "type": "Object=",
+              "description": "Object containing initial property values to\n  populate into the template bindings."
             }
           ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "Returns the created instance of\nthe template prepared by `templatize`."
+          },
           "inheritedFrom": "Polymer.Templatizer"
         },
         {
           "name": "modelForElement",
-          "description": "",
+          "description": "Returns the template \"model\" (`TemplateInstance`) associated with\na given element, which serves as the binding scope for the template\ninstance the element is contained in.  A template model should be used\nto manipulate data associated with this template instance.",
           "privacy": "public",
           "sourceRange": {
-            "file": "bower_components/polymer/polymer.html",
+            "file": "bower_components/polymer/lib/legacy/templatizer-behavior.html",
             "start": {
-              "line": 4502,
-              "column": 0
+              "line": 144,
+              "column": 6
             },
             "end": {
-              "line": 4515,
-              "column": 1
+              "line": 146,
+              "column": 7
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "el"
+              "name": "el",
+              "type": "HTMLElement",
+              "description": "Element for which to return a template model."
             }
           ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "Model representing the binding scope for\n  the element."
+          },
           "inheritedFrom": "Polymer.Templatizer"
         },
         {
@@ -1009,7 +460,24 @@
       "properties": [],
       "methods": [
         {
-          "name": "_onCosmozDialogAttached",
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 14,
+              "column": 3
+            },
+            "end": {
+              "line": 16,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "detached",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
@@ -1018,7 +486,24 @@
               "column": 3
             },
             "end": {
-              "line": 23,
+              "line": 19,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_dialogAttached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 20,
+              "column": 3
+            },
+            "end": {
+              "line": 26,
               "column": 4
             }
           },
@@ -1035,11 +520,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 13,
+          "line": 10,
           "column": 10
         },
         "end": {
-          "line": 24,
+          "line": 27,
           "column": 3
         }
       },
@@ -1058,11 +543,11 @@
           "range": {
             "file": "cosmoz-dialog-container.html",
             "start": {
-              "line": 6,
+              "line": 4,
               "column": 2
             },
             "end": {
-              "line": 6,
+              "line": 4,
               "column": 15
             }
           }
@@ -2705,11 +2190,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 59,
+              "line": 60,
               "column": 3
             },
             "end": {
-              "line": 62,
+              "line": 63,
               "column": 4
             }
           },
@@ -2722,11 +2207,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 64,
+              "line": 65,
               "column": 3
             },
             "end": {
-              "line": 67,
+              "line": 68,
               "column": 4
             }
           },
@@ -3358,11 +2843,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 45,
+              "line": 46,
               "column": 3
             },
             "end": {
-              "line": 57,
+              "line": 58,
               "column": 4
             }
           },
@@ -3379,11 +2864,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 69,
+              "line": 70,
               "column": 3
             },
             "end": {
-              "line": 75,
+              "line": 76,
               "column": 4
             }
           },
@@ -3396,11 +2881,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 81,
               "column": 3
             },
             "end": {
-              "line": 154,
+              "line": 155,
               "column": 4
             }
           },
@@ -3413,15 +2898,20 @@
         }
       ],
       "staticMethods": [],
-      "demos": [],
+      "demos": [
+        {
+          "url": "demo/index.html",
+          "description": "Dialog Demo"
+        }
+      ],
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 27,
+          "line": 28,
           "column": 10
         },
         "end": {
-          "line": 155,
+          "line": 156,
           "column": 3
         }
       },

--- a/bower.json
+++ b/bower.json
@@ -21,9 +21,8 @@
 		"tests"
 	],
 	"dependencies": {
-		"polymer": "Polymer/polymer#^1.9",
-		"paper-dialog": "PolymerElements/paper-dialog#1 - 2",
-		"iron-signals": "PolymerElements/iron-signals#^1.0.3"
+		"polymer": "Polymer/polymer#1.9 - 2",
+		"paper-dialog": "PolymerElements/paper-dialog#1 - 2"
 	},
 	"devDependencies": {
 		"paper-button": "PolymerElements/paper-button#1 - 2",
@@ -37,8 +36,7 @@
 		"1.x": {
 			"dependencies": {
 				"polymer": "Polymer/polymer#^1.9",
-				"paper-dialog": "PolymerElements/paper-dialog#^1.1.0",
-				"iron-signals": "PolymerElements/iron-signals#^1.0.3"
+				"paper-dialog": "PolymerElements/paper-dialog#^1.1.0"
 			},
 			"devDependencies": {
 				"paper-button": "PolymerElements/paper-button#^1.0.15",

--- a/bower.json
+++ b/bower.json
@@ -21,15 +21,39 @@
 		"tests"
 	],
 	"dependencies": {
-		"polymer": "^1.2.0",
-		"neon-animation": "polymerelements/neon-animation#^1.0.0",
-		"paper-dialog": "PolymerElements/paper-dialog#^1.0.0",
+		"polymer": "Polymer/polymer#^1.9",
+		"paper-dialog": "PolymerElements/paper-dialog#1 - 2",
 		"iron-signals": "PolymerElements/iron-signals#^1.0.3"
 	},
 	"devDependencies": {
-		"iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-		"web-component-tester": "Polymer/web-component-tester#^4.2.1",
-		"paper-button": "PolymerElements/paper-button#^1.0.0",
-		"iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0"
+		"paper-button": "PolymerElements/paper-button#1 - 2",
+		"iron-component-page": "PolymerElements/iron-component-page#1 - 3",
+		"iron-demo-helpers": "PolymerElements/iron-demo-helpers#1 - 2",
+		"iron-test-helpers": "PolymerElements/iron-test-helpers#1 - 2",
+		"web-component-tester": "^6.0.0",
+		"webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
+	},
+	"variants": {
+		"1.x": {
+			"dependencies": {
+				"polymer": "Polymer/polymer#^1.9",
+				"paper-dialog": "PolymerElements/paper-dialog#^1.1.0",
+				"iron-signals": "PolymerElements/iron-signals#^1.0.3"
+			},
+			"devDependencies": {
+				"paper-button": "PolymerElements/paper-button#^1.0.15",
+				"iron-component-page": "PolymerElements/iron-component-page#^2.0.0",
+				"iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.2.5",
+				"iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
+				"web-component-tester": "^4.0.0",
+				"webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+			},
+			"resolutions": {
+				"webcomponentsjs": "^0.7"
+			}
+		}
+	},
+	"resolutions": {
+		"webcomponentsjs": "^1.0.0"
 	}
 }

--- a/cosmoz-dialog-container.html
+++ b/cosmoz-dialog-container.html
@@ -1,22 +1,25 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-signals/iron-signals.html">
 
 <dom-module id="cosmoz-dialog-container">
 	<template>
-		<iron-signals on-iron-signal-cosmoz-dialog-attached="_onCosmozDialogAttached"></iron-signals>
 		<slot></slot>
 	</template>
 </dom-module>
 
 <script>
 	(function () {
-
 		Polymer({
 
 			is: 'cosmoz-dialog-container',
 
-			_onCosmozDialogAttached: function (event) {
-				var dialog = event.detail;
+			attached: function () {
+				document.addEventListener('cosmoz-dialog-attached', this._dialogAttached = this._dialogAttached.bind(this));
+			},
+			detached: function (){
+				document.removeEventListener('cosmoz-dialog-attached', this._dialogAttached);
+			},
+			_dialogAttached: function (event){
+				var dialog = event.detail.dialog;
 
 				dialog._container = this;
 				event.preventDefault();

--- a/cosmoz-dialog.html
+++ b/cosmoz-dialog.html
@@ -14,11 +14,12 @@ When this property is specified, the dialog overlay will be centered inside the 
 
 This element can be used when you want to workaround `paper-dialog` behavior that fit the backdrop to the whole window.
 
+@demo demo/index.html Dialog Demo
 -->
 <dom-module id="cosmoz-dialog">
 	<template>
 		<style include="paper-dialog-shared-styles"></style>
-		<content></content>
+		<slot></slot>
 	</template>
 </dom-module>
 
@@ -77,6 +78,8 @@ This element can be used when you want to workaround `paper-dialog` behavior tha
 
 			/**
 			 * See https://github.com/gwwar/z-context/blob/master/devtools/index.js
+			 * @param {HTMLElement|Object} nodeOrObject The node to get context for
+			 * @returns {Object} The closest stacking context
 			 */
 			_getClosestStackingContext: function (nodeOrObject) {
 				var node = nodeOrObject.node || nodeOrObject,
@@ -84,7 +87,7 @@ This element can be used when you want to workaround `paper-dialog` behavior tha
 					parentStyle;
 
 				//the root element (HTML)
-				if (! node || node.nodeName === 'HTML' || node.nodeName === '#document-fragment') {
+				if (! node || node.nodeName === 'HTML' || node.nodeName === '#document-fragment' || node.nodeName === 'DEMO-SNIPPET') {
 					return { node: document.documentElement, reason: 'root' };
 				}
 

--- a/cosmoz-dialog.html
+++ b/cosmoz-dialog.html
@@ -43,7 +43,7 @@ This element can be used when you want to workaround `paper-dialog` behavior tha
 			listeners: {
 				'neon-animation-finish': '_onNeonAnimationFinish',
 			},
-
+			// eslint-disable-next-line no-unused-vars
 			_beforeOpened: function (opened) {
 				var stackingContext;
 				if (!this.withBackdrop) {

--- a/cosmoz-dialog2.html
+++ b/cosmoz-dialog2.html
@@ -57,7 +57,7 @@ Content of the `<paper-dialog>` must be specified in a `<template>` element.
 			},
 
 			attached: function () {
-				this.fire('iron-signal', { name: 'cosmoz-dialog-attached', data: this});
+				this.fire('cosmoz-dialog-attached', { dialog: this });
 				if (!this._container) {
 					this._container = document.body;
 				}

--- a/cosmoz-dialog2.html
+++ b/cosmoz-dialog2.html
@@ -9,6 +9,7 @@ This is an attempt to workaround stacking context issues with dialogs.
 
 Content of the `<paper-dialog>` must be specified in a `<template>` element.
 
+@demo demo/index2.html Dialog2 Demo
 -->
 <dom-module id="cosmoz-dialog2">
 	<template>

--- a/demo/index.html
+++ b/demo/index.html
@@ -14,13 +14,14 @@
 	<link rel="import" href="../../paper-button/paper-button.html">
 	<link rel="import" href="../cosmoz-dialog.html">
 
-
-	<style is="custom-style" include="demo-pages-shared-styles">
-		/* This will create a new stacking context above the dialog */
-		#stackingContext {
-			transform: translateX(0);
-		}
-	</style>
+	<custom-style>
+		<style is="custom-style" include="demo-pages-shared-styles">
+			/* This will create a new stacking context above the dialog */
+			#stackingContext {
+				transform: translateX(0);
+			}
+		</style>
+	</custom-style>
 </head>
 <body unresolved>
 
@@ -63,5 +64,4 @@
 			</div>
 		</template>
 	</demo-snippet>
-</body>
-</html>
+</body></html>

--- a/demo/index2.html
+++ b/demo/index2.html
@@ -14,13 +14,14 @@
 	<link rel="import" href="../../paper-button/paper-button.html">
 	<link rel="import" href="../cosmoz-dialog2.html">
 
-	<style is="custom-style" include="demo-pages-shared-styles">
-		/* This will create a new stacking context above the dialog */
-		#stackingContext {
-			transform: translateX(0);
-		}
-	</style>
-
+	<custom-style>
+		<style is="custom-style" include="demo-pages-shared-styles">
+			/* This will create a new stacking context above the dialog */
+			#stackingContext {
+				transform: translateX(0);
+			}
+		</style>
+	</custom-style>
 </head>
 <body unresolved>
 
@@ -67,5 +68,4 @@
 			</div>
 		</template>
 	</demo-snippet>
-</body>
-</html>
+</body></html>

--- a/index.html
+++ b/index.html
@@ -3,13 +3,10 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-
 	<title>Cosmoz Dialog</title>
-
 	<script src="../webcomponentsjs/webcomponents-lite.js"></script>
 	<link rel="import" href="../iron-component-page/iron-component-page.html">
 </head>
 <body>
 	<iron-component-page></iron-component-page>
-</body>
-</html>
+</body></html>

--- a/package.json
+++ b/package.json
@@ -8,15 +8,16 @@
 	},
 	"devDependencies": {
 		"eslint": "^3.9.1",
-		"eslint-plugin-html": "^3.1.1",
+		"eslint-plugin-html": "^3.2.2",
 		"eslint-plugin-mocha": "^4.11.0",
-		"polymer-cli": "^1.5.1"
+		"polymer-cli": "^1.5.5"
 	},
 	"scripts": {
 		"start": "polymer serve -o",
-		"postinstall": "polymer install",
+		"postinstall": "polymer install --variants",
 		"lint": "eslint --cache --ext .js,.html . && polymer lint cosmoz-*.html",
-		"test": "polymer test"
+		"test": "polymer test",
+		"analyze": "polymer analyze --input cosmoz-*.html  > analysis.json"
 	},
 	"repository": {
 		"type": "git",

--- a/polymer.json
+++ b/polymer.json
@@ -1,5 +1,5 @@
 {
 	"lint": {
-		"rules": ["polymer-1"]
+		"rules": ["polymer-2-hybrid"]
 	}
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -2,13 +2,16 @@
 	"env": {
 		"mocha": true
 	},
+	"plugins": ["mocha"],
 	"globals": {
 		"a11ySuite": false,
 		"assert": false,
+		"chai": true,
+		"expect": false,
 		"fixture": false,
+		"flush": false,
 		"MockInteractions": false,
-		"suite": false,
-		"test": false,
+		"sinon": true,
 		"WCT": false
 	}
 }

--- a/test/cosmoz-dialog2_test.html
+++ b/test/cosmoz-dialog2_test.html
@@ -1,28 +1,30 @@
 <!doctype html>
 <html>
 <head>
-
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 	<title>cosmoz-dialog tests</title>
-
-	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
 
 	<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 	<script src="../../web-component-tester/browser.js"></script>
+	<script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+	<link rel="import" href="../../test-fixture/test-fixture.html">
+	<link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+
 	<link rel="import" href="../cosmoz-dialog2.html">
+	<link rel="import" href="../cosmoz-dialog-container.html">
 
-	<style is="custom-style">
-		/* This will create a new stacking context above the dialog */
-		#stackingContext {
-			transform: translateX(0);
-		}
-	</style>
-
+	<custom-style>
+		<style is="custom-style">
+			/* This will create a new stacking context above the dialog */
+			#stackingContext {
+				transform: translateX(0);
+			}
+		</style>
+	</custom-style>
 </head>
-
 <body>
-
 	<test-fixture id="withoutStackingContext">
 		<template>
 			<cosmoz-dialog2 with-backdrop>
@@ -32,7 +34,6 @@
 			</cosmoz-dialog2>
 		</template>
 	</test-fixture>
-
 	<test-fixture id="withStackingContext">
 		<template>
 			<div id="stackingContext">
@@ -44,7 +45,20 @@
 			</div>
 		</template>
 	</test-fixture>
-
+	<test-fixture id="basic">
+		<template>
+			<cosmoz-dialog2 with-backdrop>
+				<template>
+					<p>Dialog</p>
+				</template>
+			</cosmoz-dialog2>
+		</template>
+	</test-fixture>
+	<test-fixture id="basicContainer">
+		<template>
+			<cosmoz-dialog-container></cosmoz-dialog-container>
+		</template>
+	</test-fixture>
 	<script>
 		suite('withoutStackingContext', function () {
 
@@ -99,7 +113,27 @@
 			});
 
 		});
-		</script>
 
+		suite('container', function (){
+			var container,
+				dialog;
+
+			setup(function (done){
+				container = fixture('basicContainer');
+				dialog = fixture('basic');
+				flush(done);
+			});
+
+			test('has container', function (done) {
+				assert.equal(dialog._container, container);
+				dialog.paperDialog.addEventListener('iron-overlay-opened', function () {
+					assert.equal(dialog.paperDialog.parentNode, container);
+					done();
+				});
+				dialog.open();
+			});
+
+		});
+		</script>
 	</body>
 </html>

--- a/test/cosmoz-dialog2_test.html
+++ b/test/cosmoz-dialog2_test.html
@@ -34,6 +34,7 @@
 			</cosmoz-dialog2>
 		</template>
 	</test-fixture>
+
 	<test-fixture id="withStackingContext">
 		<template>
 			<div id="stackingContext">
@@ -45,6 +46,7 @@
 			</div>
 		</template>
 	</test-fixture>
+
 	<test-fixture id="basic">
 		<template>
 			<cosmoz-dialog2 with-backdrop>
@@ -54,11 +56,13 @@
 			</cosmoz-dialog2>
 		</template>
 	</test-fixture>
+
 	<test-fixture id="basicContainer">
 		<template>
 			<cosmoz-dialog-container></cosmoz-dialog-container>
 		</template>
 	</test-fixture>
+
 	<script>
 		suite('withoutStackingContext', function () {
 
@@ -73,6 +77,7 @@
 							backdropElementSize = dialog.paperDialog.backdropElement.getBoundingClientRect(),
 							expectedDialogElement,
 							expectedBackdrop;
+
 						expectedDialogElement = document.elementFromPoint(dialogSize.left + 1, dialogSize.top + 1);
 						expectedBackdrop = document.elementFromPoint(dialogSize.left - 1, dialogSize.top - 1);
 
@@ -100,6 +105,7 @@
 							backdropElementSize = dialog.paperDialog.backdropElement.getBoundingClientRect(),
 							expectedDialogElement,
 							expectedBackdrop;
+
 						expectedDialogElement = document.elementFromPoint(dialogSize.left + 1, dialogSize.top + 1);
 						expectedBackdrop = document.elementFromPoint(dialogSize.left - 1, dialogSize.top - 1);
 
@@ -134,6 +140,5 @@
 			});
 
 		});
-		</script>
-	</body>
-</html>
+	</script>
+</body></html>

--- a/test/cosmoz-dialog_test.html
+++ b/test/cosmoz-dialog_test.html
@@ -1,26 +1,27 @@
 <!doctype html>
 <html>
-
 <head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+	<title>cosmoz-dialog tests</title>
 
-		<title>cosmoz-dialog tests</title>
+	<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+	<script src="../../web-component-tester/browser.js"></script>
+	<script src="../../test-fixture/test-fixture-mocha.js"></script>
 
-		<meta charset="utf-8">
-		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+	<link rel="import" href="../../test-fixture/test-fixture.html">
+	<link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
 
-		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-		<script src="../../web-component-tester/browser.js"></script>
-		<link rel="import" href="../cosmoz-dialog.html">
+	<link rel="import" href="../cosmoz-dialog.html">
 
-		<style>
+	<custom-style>
+		<style is="custom-style">
 			#stackingContext {
 					transform: translateX(0);
 			}
 		</style>
-
+	</custom-style>
 </head>
-
 <body>
 	<test-fixture id="withoutStackingContext">
 		<template>

--- a/test/cosmoz-dialog_test.html
+++ b/test/cosmoz-dialog_test.html
@@ -95,6 +95,5 @@
 
 			});
 		});
-		</script>
-	</body>
-</html>
+	</script>
+</body></html>

--- a/test/cosmoz-dialog_test.html
+++ b/test/cosmoz-dialog_test.html
@@ -55,6 +55,7 @@
 							backdropElementSize = dialog.backdropElement.getBoundingClientRect(),
 							expectedDialogElement,
 							expectedBackdrop;
+
 						expectedDialogElement = document.elementFromPoint(dialogSize.left + 1, dialogSize.top + 1);
 						expectedBackdrop = document.elementFromPoint(dialogSize.left - 1, dialogSize.top - 1);
 
@@ -82,6 +83,7 @@
 							backdropElementSize = dialog.backdropElement.getBoundingClientRect(),
 							expectedDialogElement,
 							expectedBody;
+
 						expectedDialogElement = document.elementFromPoint(dialogSize.left + 1, dialogSize.top + 1);
 						expectedBody = document.elementFromPoint(dialogSize.left - 1, dialogSize.top - 1);
 

--- a/test/index.html
+++ b/test/index.html
@@ -1,21 +1,24 @@
-<!DOCTYPE html>
-<html><head>
-
-		<title>cosmoz-dialog tests</title>
-
-		<meta charset="utf-8">
-		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-
-		<script src="../../web-component-tester/browser.js"></script>
-
-	</head>
-	<body>
-		<script>
-			WCT.loadSuites([
+<!doctype html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+	<title>cosmoz-dialog tests</title>
+	<script src="../../web-component-tester/browser.js"></script>
+</head>
+<body>
+	<script>
+		var pages = [
 				'cosmoz-dialog_test.html',
 				'cosmoz-dialog2_test.html',
-			]);
-		</script>
+			],
+			suites = [],
+			i;
 
+		for (i = 0; i < pages.length; i++) {
+			suites.push(pages[i] + '?dom=shadow');
+			suites.push(pages[i] + '?wc-shadydom=true&wc-ce=true');
+		}
+		WCT.loadSuites(suites);
+	</script>
 </body></html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@polymer/sinonjs/-/sinonjs-1.17.1.tgz#e47d3785b7d0e8c29feb97f7e924b0fc597e2e9b"
 
-"@polymer/test-fixture@^3.0.0-pre.1":
-  version "3.0.0-pre.1"
-  resolved "https://registry.yarnpkg.com/@polymer/test-fixture/-/test-fixture-3.0.0-pre.1.tgz#3d8894cfb51f0b4b5e1b9fb0fc8eab8293a61e6d"
+"@polymer/test-fixture@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@polymer/test-fixture/-/test-fixture-0.0.3.tgz#4443752697d4d9293bbc412ea0b5e4d341f149d9"
 
 "@types/assert@0.0.29":
   version "0.0.29"
@@ -39,7 +39,7 @@
   version "6.25.1"
   resolved "https://registry.yarnpkg.com/@types/babel-types/-/babel-types-6.25.1.tgz#ce8f126a4403e11e1b0033a424f11638afac7889"
 
-"@types/babylon@*":
+"@types/babylon@*", "@types/babylon@^6.16.2":
   version "6.16.2"
   resolved "https://registry.yarnpkg.com/@types/babylon/-/babylon-6.16.2.tgz#062ce63b693d9af1c246f5aedf928bc9c30589c8"
   dependencies:
@@ -390,7 +390,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/ua-parser-js@^0.7.30":
+"@types/ua-parser-js@^0.7.30", "@types/ua-parser-js@^0.7.31":
   version "0.7.32"
   resolved "https://registry.yarnpkg.com/@types/ua-parser-js/-/ua-parser-js-0.7.32.tgz#8827d451d6702307248073b5d98aa9293d02b5e5"
 
@@ -1231,7 +1231,7 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@^6.18.0:
+babylon@^6.17.4, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
@@ -1347,6 +1347,13 @@ braces@^1.8.2:
     expand-range "^1.8.1"
     preserve "^0.2.0"
     repeat-element "^1.1.2"
+
+browser-capabilities@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/browser-capabilities/-/browser-capabilities-0.2.0.tgz#5fc2cff65bc9f40ec6903d574d965e9e1f10a581"
+  dependencies:
+    "@types/ua-parser-js" "^0.7.31"
+    ua-parser-js "^0.7.14"
 
 browser-stdout@1.3.0:
   version "1.3.0"
@@ -2147,11 +2154,12 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-plugin-html@^3.1.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-html/-/eslint-plugin-html-3.2.0.tgz#fb64c2789e9582b97f580a38814a57966f91a7b2"
+eslint-plugin-html@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-html/-/eslint-plugin-html-3.2.2.tgz#ef7093621d3a93de3206fd1f92f347ea9a1a4dfa"
   dependencies:
     htmlparser2 "^3.8.2"
+    semver "^5.4.1"
 
 eslint-plugin-mocha@^4.11.0:
   version "4.11.0"
@@ -2512,6 +2520,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+  dependencies:
+    samsam "~1.1"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -3003,6 +3017,10 @@ inflight@^1.0.4:
 inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+inherits@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
@@ -3513,6 +3531,10 @@ log-symbols@^1.0.1:
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
   dependencies:
     chalk "^1.0.0"
+
+lolex@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
 
 loose-envify@^1.0.0:
   version "1.3.1"
@@ -4182,9 +4204,9 @@ polymer-bundler@^3.0.1:
     polymer-analyzer "^2.0.0"
     source-map "^0.5.6"
 
-polymer-cli@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/polymer-cli/-/polymer-cli-1.5.1.tgz#1db68c1221e80dab85770fe23a7fe51e59d032d9"
+polymer-cli@^1.5.5:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/polymer-cli/-/polymer-cli-1.5.5.tgz#bc758b79e689fa35ed6172681bc971a085081f27"
   dependencies:
     "@types/babel-core" "^6.7.14"
     "@types/chalk" "^0.4.31"
@@ -4230,7 +4252,7 @@ polymer-cli@^1.5.1:
     polymer-build "^2.0.0"
     polymer-linter "^2.0.2"
     polymer-project-config "^3.4.0"
-    polyserve "^0.20.0"
+    polyserve "^0.22.1"
     request "^2.72.0"
     rimraf "^2.6.1"
     semver "^5.3.0"
@@ -4239,7 +4261,7 @@ polymer-cli@^1.5.1:
     update-notifier "^1.0.0"
     vinyl "^1.1.1"
     vinyl-fs "^2.4.3"
-    web-component-tester "^6.1.2"
+    web-component-tester "^6.2.0"
     yeoman-environment "^1.5.2"
     yeoman-generator "^1.0.1"
 
@@ -4267,12 +4289,13 @@ polymer-project-config@^3.2.1, polymer-project-config@^3.4.0:
     minimatch-all "^1.1.0"
     plylog "^0.5.0"
 
-polyserve@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/polyserve/-/polyserve-0.20.0.tgz#0ea78702224d26f1ed4c7f564bbfee627786763e"
+polyserve@^0.22.1:
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/polyserve/-/polyserve-0.22.1.tgz#f78cf23f932fdad028a246dd72db74a4ce4955d0"
   dependencies:
     "@types/assert" "0.0.29"
     "@types/babel-core" "^6.7.14"
+    "@types/babylon" "^6.16.2"
     "@types/compression" "^0.0.33"
     "@types/content-type" "^1.1.0"
     "@types/express" "^4.0.36"
@@ -4296,6 +4319,7 @@ polyserve@^0.20.0:
     babel-plugin-transform-es2015-for-of "^6.18.0"
     babel-plugin-transform-es2015-function-name "^6.9.0"
     babel-plugin-transform-es2015-literals "^6.8.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.1"
     babel-plugin-transform-es2015-object-super "^6.8.0"
     babel-plugin-transform-es2015-parameters "^6.18.0"
     babel-plugin-transform-es2015-shorthand-properties "^6.18.0"
@@ -4305,6 +4329,8 @@ polyserve@^0.20.0:
     babel-plugin-transform-es2015-typeof-symbol "^6.18.0"
     babel-plugin-transform-es2015-unicode-regex "^6.11.0"
     babel-plugin-transform-regenerator "^6.16.1"
+    babylon "^6.17.4"
+    browser-capabilities "^0.2.0"
     command-line-args "^3.0.1"
     command-line-usage "^3.0.3"
     compression "^1.6.2"
@@ -4320,10 +4346,10 @@ polyserve@^0.20.0:
     parse5 "^2.2.3"
     pem "^1.8.3"
     polymer-build "^2.0.0"
+    requirejs "^2.3.4"
     resolve "^1.0.0"
     send "^0.14.1"
     spdy "^3.3.3"
-    ua-parser-js "^0.7.12"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -4688,6 +4714,10 @@ require-uncached@^1.0.2:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+requirejs@^2.3.4:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.3.5.tgz#617b9acbbcb336540ef4914d790323a8d4b861b0"
+
 requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -4750,6 +4780,14 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, s
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+samsam@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+
+samsam@~1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.3.tgz#9f5087419b4d091f232571e7fa52e90b0f552621"
+
 sauce-connect-launcher@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sauce-connect-launcher/-/sauce-connect-launcher-1.2.2.tgz#7346cc8fbdc443191323439b0733451f5f3521f2"
@@ -4786,7 +4824,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
@@ -4899,6 +4937,15 @@ signal-exit@^3.0.0:
 sinon-chai@^2.10.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.13.0.tgz#b9a42e801c20234bfc2f43b29e6f4f61b60990c4"
+
+sinon@^1.17.1:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+  dependencies:
+    formatio "1.1.1"
+    lolex "1.3.2"
+    samsam "1.1.2"
+    util ">=0.10.3 <1"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -5408,7 +5455,7 @@ typical@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"
 
-ua-parser-js@^0.7.12:
+ua-parser-js@^0.7.14:
   version "0.7.14"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
 
@@ -5503,6 +5550,12 @@ user-home@^2.0.0:
 util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+"util@>=0.10.3 <1":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  dependencies:
+    inherits "2.0.1"
 
 utils-merge@1.0.0:
   version "1.0.0"
@@ -5648,12 +5701,12 @@ wd@^1.2.0:
     underscore.string "3.3.4"
     vargs "0.1.0"
 
-web-component-tester@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/web-component-tester/-/web-component-tester-6.1.2.tgz#b2c559f1598f2dbbf5c7adacdf48b3ac06081fdb"
+web-component-tester@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/web-component-tester/-/web-component-tester-6.2.0.tgz#6ca92f9e7671e97273c6850ab8d3f9fae8b175ff"
   dependencies:
     "@polymer/sinonjs" "^1.14.1"
-    "@polymer/test-fixture" "^3.0.0-pre.1"
+    "@polymer/test-fixture" "^0.0.3"
     "@webcomponents/webcomponentsjs" "^1.0.7"
     accessibility-developer-tools "^2.12.0"
     async "^1.5.2"
@@ -5668,12 +5721,13 @@ web-component-tester@^6.1.2:
     mocha "^3.4.2"
     multer "^1.3.0"
     nomnom "^1.8.1"
-    polyserve "^0.20.0"
+    polyserve "^0.22.1"
     promisify-node "^0.4.0"
     resolve "^1.3.3"
     semver "^5.3.0"
     send "^0.11.1"
     server-destroy "^1.0.1"
+    sinon "^1.17.1"
     sinon-chai "^2.10.0"
     socket.io "^1.7.4"
     stacky "^1.3.1"


### PR DESCRIPTION
Hybrid element
Variants
Demo and test fixes
Replace `iron-signals` with  a simple `cosmoz-dialog-attached` event because `iron-signals` is deprecated and there won't be 2.0 version.
Added tests for `cosmoz-dialog-attached` event.
Fixed `cosmoz-dialog` inside `demo-snippet`  withBackdrop.